### PR TITLE
Adding totd deamon to feeds

### DIFF
--- a/totd/Makefile
+++ b/totd/Makefile
@@ -1,0 +1,60 @@
+#
+# Copyright (C) 2006-2011 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=totd
+PKG_VERSION:=1.5.3
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/fwdillema/totd.git
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_VERSION:=$(PKG_VERSION)
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/totd
+  SECTION:=ipv6
+  CATEGORY:=IPv6
+  DEPENDS:=+kmod-ipv6
+  TITLE:=Small DNS proxy that supports IPv6/IPv4 record translation
+  URL:=http://www.dillema.net/software/totd.html
+endef
+
+define Package/totd/description
+	totd is a small DNS proxy nameserver which supports IPv6 and enable IPv6
+	only sites to access IPv4 sites by using some translation mechanism such
+	as NAT-PT, KAME faith, etc...
+endef
+
+define Package/totd/conffiles
+/etc/totd.conf
+endef
+
+# uses GNU configure
+
+define Build/Compile
+	$(MAKE) -C $(PKG_BUILD_DIR) \
+		DESTDIR="$(PKG_INSTALL_DIR)" \
+		CC="$(TARGET_CC)" \
+		all
+endef
+
+define Package/totd/install
+	$(INSTALL_DIR) $(1)/usr/sbin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/$(PKG_NAME) $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/etc/
+	$(INSTALL_CONF) ./files/totd.conf $(1)/etc/
+	$(INSTALL_DIR) $(1)/etc/init.d/
+	$(INSTALL_BIN) ./files/totd.init $(1)/etc/init.d/totd
+endef
+
+$(eval $(call BuildPackage,totd))
+

--- a/totd/files/totd.conf
+++ b/totd/files/totd.conf
@@ -1,0 +1,17 @@
+; Totd sample configuration file
+; you can have multiple forwarders, totd will always prefer
+; forwarders listed early and only use forwarders listed later
+; if the first ones are unresponsive.
+forwarder 192.168.1.1 port 5353
+; you can have multiple prefixes or even no prefixes at all
+; totd uses them in round-robin fashion
+prefix 3ffe:abcd:1234:9876::
+; the port totd listens on for incoming requests
+port 53
+; the pidfile to use (default: /var/run/totd.pid)
+pidfile /var/run/totd.pid
+; interfaces totd listens on (UDP only for now and not on Linux)
+; If left out totd will only open wildcard sockets.
+; interfaces lo br0
+; 6to4 reverse lookup
+; stf

--- a/totd/files/totd.init
+++ b/totd/files/totd.init
@@ -1,0 +1,23 @@
+#!/bin/sh /etc/rc.common
+# Copyright (C) 2006 OpenWrt.org
+
+START=60
+BIN=totd
+RUN_D=/var/run
+PID_F=$RUN_D/$BIN.pid
+
+
+start() {
+	mkdir -p $RUN_D
+	$BIN -c /etc/totd.conf
+}
+
+stop() {
+	[ -f $PID_F ] && kill $(cat $PID_F)
+}
+
+restart() {
+	stop
+	sleep 1
+	start
+}


### PR DESCRIPTION
This tool can be used to configure DNS for constrained devices.